### PR TITLE
Fixed incorrect assigning of custom $loop and $client

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -62,8 +62,8 @@ class Client implements HttpClient, HttpAsyncClient
                 'You must give a LoopInterface instance with the Client'
             );
         }
-        $this->loop = (null !== $loop) ?: ReactFactory::buildEventLoop();
-        $this->client = (null !== $client) ?: ReactFactory::buildHttpClient($this->loop);
+        $this->loop = $loop ?: ReactFactory::buildEventLoop();
+        $this->client = $client ?: ReactFactory::buildHttpClient($this->loop);
 
         $this->messageFactory = $messageFactory ?: MessageFactoryDiscovery::find();
     }


### PR DESCRIPTION
In the check `(null !== $loop) ?: ReactFactory::buildEventLoop()`, the $loop property is a boolean if you give a custom $loop instance through the constructor. The same for the $client instance. This is a fix for both.