### PR TITLE
Fix react/http-client 0.4.13 response body issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [Unreleased]
+
+### Fixed
+
+- Issue with `react/http-client` v0.4.13 about body handling as StreamInterface.
+This change was introduce in https://github.com/reactphp/http-client/pull/66.
+
+### Changed
+
+- Client now require a Stream factory to handle body properly.
+
 
 ## 0.2.2 - 2016-07-18
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "php-http/discovery": "^1.0"
     },
     "require-dev": {
-        "php-http/client-integration-tests": "^0.5.1"
+        "php-http/client-integration-tests": "^0.5.1",
+        "php-http/message": "^1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Related tickets | fixes #17 |
| Documentation |  |
| License | MIT |
#### What's in this PR?

This PR has been pushed to fixed the compatibility error with `react/http-client` v0.4.13.
#### Why?

There was a break change published in v0.4.13 around response body type. Before the first response body was sent as a `StreamInterface` instance, now it's "just" string.

Before we are using that `StreamInterface` instance as `$bodyStream`... Now it has been updated to use the `Http\Message\StreamFactory` to build a valid StreamInterface instance.

If a BC Break because I've introduced a new constructor parameter to be able to inject `StreamFactory` instance...

Of course the `Http\Discovery\StreamFactoryDiscovery` object is used when parameter is empty.

With this change, I've tested on lowest dependencies and it works too.
#### Checklist
- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
#### To Do
- [x] Validate PR approach...
- [ ] Create a release with a composer update to disallow react/http-client > 0.4.12 ?
