### PR TITLE
fix branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.4-dev"
+            "dev-master": "2.0-dev"
         }
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

Fix branch alias for the master branch as there is version 2.0.0 already.


#### Why?

The branch alias must reflect the latest commit tag. Once we add a new feature, it should bump to 2.1, if we do a BC break, it must go to 3.0 so that people requiring on `^2.0@dev` get the right version of the code.
