### PR TITLE
Fix composer version conflict with react/http v0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## 2.1.0 - 2017-12-20
+
+### Changed
+
+- Added compatibility with `react/http-client` v0.5 (compatibility with v0.4 kept)
+- `ReactFactory::buildHttpClient` now accepts a `\React\Socket\ConnectorInterface` (only for `react/http-client` v0.5).
+If none provided, will use React HTTP Client defaults. 
+
+### Deprecations
+- Passing a `\React\Dns\Resolver\Resolver` to `ReactFactory::buildHttpClient` is deprecated and will be removed in **3.0.0**.
+To control connector behavior (DNS, timeout, etc), pass a `\React\Socket\ConnectorInterface` instead.
+
 ## 2.0.0 - 2017-09-18
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,10 @@
     "require": {
         "php": "^5.5 || ^7.0",
         "php-http/httplug": "^1.0",
-        "react/http-client": "^0.4.8",
+        "react/http-client": "^0.5",
         "react/dns": "^0.4.1",
-        "react/stream": "^0.4.3",
+        "react/stream": "^0.4.3 || ^0.7",
+        "react/socket": "^0.8",
         "php-http/discovery": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^5.5 || ^7.0",
         "php-http/httplug": "^1.0",
-        "react/http-client": "^0.5",
+        "react/http-client": "^0.4.8 || ^0.5",
         "react/dns": "^0.4.1",
         "react/stream": "^0.4.3 || ^0.7",
         "react/socket": "^0.8",
@@ -21,7 +21,8 @@
     },
     "require-dev": {
         "php-http/client-integration-tests": "^0.6",
-        "php-http/message": "^1.0"
+        "php-http/message": "^1.0",
+        "phpunit/phpunit": "^4.8.36 || ^5.4"
     },
     "provide": {
         "php-http/client-implementation": "1.0",

--- a/src/ReactFactory.php
+++ b/src/ReactFactory.php
@@ -64,8 +64,9 @@ class ReactFactory
      * Build a React Http Client.
      *
      * @param LoopInterface                       $loop
-     * @param ConnectorInterface|DnsResolver|null $connector Passing a DnsResolver instance is deprecated. Should pass a
-     *                                                       ConnectorInterface instance.
+     * @param ConnectorInterface|DnsResolver|null $connector Only pass this argument if you need to customize DNS
+     *                                                       behaviour. With react http client v0.5, pass a connector,
+     *                                                       with v0.4 this must be a DnsResolver.
      *
      * @return HttpClient
      */
@@ -89,7 +90,7 @@ class ReactFactory
      *
      * @return HttpClient
      */
-    private static function buildHttpClient04(
+    protected static function buildHttpClient04(
         LoopInterface $loop,
         $dns = null
     ) {
@@ -100,7 +101,7 @@ class ReactFactory
 
         // validate connector instance for proper error reporting
         if (!$dns instanceof DnsResolver) {
-            throw new \InvalidArgumentException('$connector must be an instance of DnsResolver');
+            throw new \InvalidArgumentException('For react http client v0.4, $dns must be an instance of DnsResolver');
         }
 
         $factory = new HttpClientFactory();
@@ -116,12 +117,20 @@ class ReactFactory
      *
      * @return HttpClient
      */
-    private static function buildHttpClient05(
+    protected static function buildHttpClient05(
         LoopInterface $loop,
         $connector = null
     ) {
         // build a connector with given DnsResolver if provided (old deprecated behavior)
         if ($connector instanceof DnsResolver) {
+            @trigger_error(
+                sprintf(
+                    'Passing a %s to buildHttpClient is deprecated since version 2.1.0 and will be removed in 3.0. If you need no specific behaviour, omit the $dns argument, otherwise pass a %s',
+                    DnsResolver::class,
+                    ConnectorInterface::class
+                ),
+                E_USER_DEPRECATED
+            );
             $connector = static::buildConnector($loop, $connector);
         }
 

--- a/src/ReactFactory.php
+++ b/src/ReactFactory.php
@@ -7,6 +7,7 @@ use React\EventLoop\Factory as EventLoopFactory;
 use React\Dns\Resolver\Resolver as DnsResolver;
 use React\Dns\Resolver\Factory as DnsResolverFactory;
 use React\HttpClient\Client as HttpClient;
+use React\HttpClient\Factory as HttpClientFactory;
 use React\Socket\Connector;
 use React\Socket\ConnectorInterface;
 
@@ -54,19 +55,17 @@ class ReactFactory
         LoopInterface $loop,
         DnsResolver $dns = null
     ) {
-        if (null === $dns) {
-            $dns = self::buildDnsResolver($loop);
-        }
-
-        return new Connector($loop, ['dns' => $dns]);
+        return null !== $dns
+            ? new Connector($loop, ['dns' => $dns])
+            : new Connector($loop);
     }
 
     /**
      * Build a React Http Client.
      *
-     * @param LoopInterface                  $loop
-     * @param ConnectorInterface|DnsResolver $connector Passing a DnsResolver instance is deprecated. Should pass a
-     *                                                  ConnectorInterface instance.
+     * @param LoopInterface                       $loop
+     * @param ConnectorInterface|DnsResolver|null $connector Passing a DnsResolver instance is deprecated. Should pass a
+     *                                                       ConnectorInterface instance.
      *
      * @return HttpClient
      */
@@ -74,13 +73,63 @@ class ReactFactory
         LoopInterface $loop,
         $connector = null
     ) {
-        // build a connector if none is given, or create one attaching given DnsResolver (old deprecated behavior)
-        if (null === $connector || $connector instanceof DnsResolver) {
+        if (class_exists(HttpClientFactory::class)) {
+            // if HttpClientFactory class exists, use old behavior for backwards compatibility
+            return static::buildHttpClient04($loop, $connector);
+        } else {
+            return static::buildHttpClient05($loop, $connector);
+        }
+    }
+
+    /**
+     * Builds a React Http client v0.4 style
+     *
+     * @param LoopInterface    $loop
+     * @param DnsResolver|null $dns
+     *
+     * @return HttpClient
+     */
+    private static function buildHttpClient04(
+        LoopInterface $loop,
+        $dns = null
+    ) {
+        // create dns resolver if one isn't provided
+        if (null === $dns) {
+            $dns = static::buildDnsResolver($loop);
+        }
+
+        // validate connector instance for proper error reporting
+        if (!$dns instanceof DnsResolver) {
+            throw new \InvalidArgumentException('$connector must be an instance of DnsResolver');
+        }
+
+        $factory = new HttpClientFactory();
+
+        return $factory->create($loop, $dns);
+    }
+
+    /**
+     * Builds a React Http client v0.5 style
+     *
+     * @param LoopInterface                       $loop
+     * @param DnsResolver|ConnectorInterface|null $connector
+     *
+     * @return HttpClient
+     */
+    private static function buildHttpClient05(
+        LoopInterface $loop,
+        $connector = null
+    ) {
+        // build a connector with given DnsResolver if provided (old deprecated behavior)
+        if ($connector instanceof DnsResolver) {
             $connector = static::buildConnector($loop, $connector);
         }
 
-        if (!$connector instanceof ConnectorInterface) {
-            throw new \InvalidArgumentException('$connector must be an instance of ConnectorInterface or DnsResolver');
+        // validate connector instance for proper error reporting
+        if (null !== $connector && !$connector instanceof ConnectorInterface) {
+            throw new \InvalidArgumentException(
+                '$connector must be an instance of DnsResolver or ConnectorInterface'
+            );
         }
 
         return new HttpClient($loop, $connector);

--- a/src/ReactFactory.php
+++ b/src/ReactFactory.php
@@ -6,8 +6,9 @@ use React\EventLoop\LoopInterface;
 use React\EventLoop\Factory as EventLoopFactory;
 use React\Dns\Resolver\Resolver as DnsResolver;
 use React\Dns\Resolver\Factory as DnsResolverFactory;
-use React\HttpClient\Factory as HttpClientFactory;
 use React\HttpClient\Client as HttpClient;
+use React\Socket\Connector;
+use React\Socket\DnsConnector;
 
 /**
  * Factory wrapper for React instances.
@@ -55,12 +56,25 @@ class ReactFactory
         LoopInterface $loop,
         DnsResolver $dns = null
     ) {
+        $dnsConnector = static::buildDnsConnector($loop, $dns);
+
+        return new HttpClient($loop, $dnsConnector);
+    }
+
+    /**
+     * @param LoopInterface    $loop
+     * @param DnsResolver|null $dns
+     *
+     * @return DnsConnector
+     */
+    public static function buildDnsConnector(
+        LoopInterface $loop,
+        DnsResolver $dns = null
+    ) {
         if (null === $dns) {
             $dns = self::buildDnsResolver($loop);
         }
 
-        $factory = new HttpClientFactory();
-
-        return $factory->create($loop, $dns);
+        return new DnsConnector(new Connector($loop), $dns);
     }
 }

--- a/src/ReactFactory.php
+++ b/src/ReactFactory.php
@@ -82,7 +82,7 @@ class ReactFactory
     }
 
     /**
-     * Builds a React Http client v0.4 style
+     * Builds a React Http client v0.4 style.
      *
      * @param LoopInterface    $loop
      * @param DnsResolver|null $dns
@@ -109,7 +109,7 @@ class ReactFactory
     }
 
     /**
-     * Builds a React Http client v0.5 style
+     * Builds a React Http client v0.5 style.
      *
      * @param LoopInterface                       $loop
      * @param DnsResolver|ConnectorInterface|null $connector

--- a/tests/ReactFactoryTest.php
+++ b/tests/ReactFactoryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Http\Adapter\React\Tests;
+
+use Http\Adapter\React\ReactFactory;
+use PHPUnit\Framework\TestCase;
+use React\Dns\Resolver\Resolver;
+use React\EventLoop\LoopInterface;
+use React\HttpClient\Client;
+use React\Socket\ConnectorInterface;
+
+/**
+ * These tests don't really ensure the correct instances are baked into the returned http client, instead, they are
+ * just testing the code against the expected use cases.
+ *
+ * @author  Samuel Nogueira <samuel.nogueira@jumia.com>
+ */
+class ReactFactoryTest extends TestCase
+{
+    /**
+     * @var \React\EventLoop\LoopInterface
+     */
+    private $loop;
+
+    protected function setUp()
+    {
+        $this->loop = $this->createMock(LoopInterface::class);
+    }
+
+    public function testBuildHttpClientWithConnector()
+    {
+        $client = ReactFactory::buildHttpClient($this->loop, $this->createMock(ConnectorInterface::class));
+        $this->assertInstanceOf(Client::class, $client);
+    }
+
+    /**
+     * @deprecated Building HTTP client passing a DnsResolver instance is deprecated. Should pass a ConnectorInterface
+     *             instance instead.
+     */
+    public function testBuildHttpClientWithDnsResolver()
+    {
+        $client = ReactFactory::buildHttpClient($this->loop, $this->createMock(Resolver::class));
+        $this->assertInstanceOf(Client::class, $client);
+    }
+
+    public function testBuildHttpClientWithoutConnector()
+    {
+        $client = ReactFactory::buildHttpClient($this->loop);
+        $this->assertInstanceOf(Client::class, $client);
+    }
+
+    public function testBuildHttpClientWithInvalidConnectorThrowsException()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        ReactFactory::buildHttpClient($this->loop, $this->createMock(LoopInterface::class));
+    }
+}

--- a/tests/ReactFactoryTest.php
+++ b/tests/ReactFactoryTest.php
@@ -35,7 +35,7 @@ class ReactFactoryTest extends TestCase
         }
 
         $connector = $this->getMockBuilder(ConnectorInterface::class)->getMock();
-        $client    = ReactFactory::buildHttpClient($this->loop, $connector);
+        $client = ReactFactory::buildHttpClient($this->loop, $connector);
         $this->assertInstanceOf(Client::class, $client);
     }
 
@@ -46,7 +46,7 @@ class ReactFactoryTest extends TestCase
     public function testBuildHttpClientWithDnsResolver()
     {
         $connector = $this->getMockBuilder(Resolver::class)->disableOriginalConstructor()->getMock();
-        $client    = ReactFactory::buildHttpClient($this->loop, $connector);
+        $client = ReactFactory::buildHttpClient($this->loop, $connector);
         $this->assertInstanceOf(Client::class, $client);
     }
 


### PR DESCRIPTION
 - Upgraded dependency on react/http-client
 - Introduced dependency on react/socket so \Http\Adapter\React\buildDnsResolver and \Http\Adapter\React\buildHttpClient remain usable as before (no need for major version bump on php-http/react-adapter)

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #25 
| License         | MIT


#### What's in this PR?

Upgraded dependency on react/http-client
Introduced dependency on react/socket so \Http\Adapter\React\buildDnsResolver and \Http\Adapter\React\buildHttpClient remain usable as before (no need for major version bump on php-http/react-adapter)
