### PR TITLE
Improve interoperability with reactphp/promise

### DIFF
--- a/src/Promise.php
+++ b/src/Promise.php
@@ -81,7 +81,9 @@ final class Promise implements HttpPromise
 
         $this->onFulfilled = function (ResponseInterface $response) use ($onFulfilled, $newPromise) {
             try {
-                $newPromise->resolve($onFulfilled($response));
+                $return = $onFulfilled($response);
+
+                $newPromise->resolve(null !== $return ? $return : $response);
             } catch (Exception $exception) {
                 $newPromise->reject($exception);
             }

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Psr7\Response;
 use Http\Adapter\React\Promise;
 use Http\Adapter\React\ReactFactory;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
 
 class PromiseTest extends TestCase
 {
@@ -30,5 +31,26 @@ class PromiseTest extends TestCase
 
         self::assertEquals(200, $response->getStatusCode());
         self::assertEquals(300, $updatedResponse->getStatusCode());
+    }
+
+    public function testOnFulfilledOptionalReturn()
+    {
+        $promise = new Promise($this->loop);
+        $response = new Response(200);
+
+        // create a random mock so we can assert $onFulfilled is called with the correct response
+        /** @var \SplObjectStorage|\PHPUnit_Framework_MockObject_MockObject $mock */
+        $mock = $this->getMockBuilder(\SplObjectStorage::class)->getMock();
+        $mock->expects(self::once())->method('attach')->with($response);
+
+        $lastPromise = $promise->then(function (ResponseInterface $response) use ($mock) {
+            $mock->attach($response);
+        });
+
+        $promise->resolve($response);
+        $lastResponse = $lastPromise->wait();
+
+        // even though our $onFulfilled doesn't return a value, we expect the promise to unwrap the original response
+        self::assertSame($response, $lastResponse);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #30 
| License         | MIT


#### What's in this PR?

`$onFulfilled` callables passed to `Http\Adapter\React\Promise::then` are no longer required to return the response.

#### Example Usage

``` php
/** @var \Http\Adapter\React\Client $client */
/** @var \Psr\Http\Message\RequestInterface $request */
$client->sendAsyncRequest($request)->then(function (\Psr\Http\Message\ResponseInterface $response) {
    echo $response->getBody();
});
```

