### PR TITLE
Fix BC break

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "react/http-client": "~0.5.9",
         "react/dns": "^0.4.1",
         "react/socket": "^0.8",
+        "react/event-loop": "^0.5 || ^1.0",
         "php-http/discovery": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "react/http-client": "~0.5.9",
         "react/dns": "^0.4.15",
         "react/socket": "^1.0",
+        "react/stream": "^1.0",
         "react/event-loop": "^1.0",
         "php-http/discovery": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         "php": "^5.5 || ^7.0",
         "php-http/httplug": "^1.0",
         "react/http-client": "~0.5.9",
-        "react/dns": "^0.4.1",
-        "react/socket": "^0.8",
-        "react/event-loop": "^0.5 || ^1.0",
+        "react/dns": "^0.4.15",
+        "react/socket": "^1.0",
+        "react/event-loop": "^1.0",
         "php-http/discovery": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^5.5 || ^7.0",
         "php-http/httplug": "^1.0",
-        "react/http-client": "^0.4.8 || ^0.5",
+        "react/http-client": "~0.5.9",
         "react/dns": "^0.4.1",
         "react/socket": "^0.8",
         "php-http/discovery": "^1.0"

--- a/src/Promise.php
+++ b/src/Promise.php
@@ -175,8 +175,12 @@ final class Promise implements HttpPromise
      */
     public function wait($unwrap = true)
     {
+        $loop = $this->loop;
         while (HttpPromise::PENDING === $this->getState()) {
-            $this->loop->tick();
+            $loop->futureTick(function () use ($loop) {
+                $loop->stop();
+            });
+            $loop->run();
         }
 
         if ($unwrap) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | fixes #32 
| Documentation   |
| License         | MIT


#### What's in this PR?

Adds a workaround for missing `LoopInterface::tick()` method.


#### Why?

Since `react/http-client` utilizes newer versions of `react/event-loop` which have BC in them, the `tick()` method no longer exists. [This PR adds a workaround to fix that.](
https://github.com/reactphp/event-loop/pull/52#issuecomment-239688446)

#### Example Usage

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks (composer.json requirements)

