### PR TITLE
Update react/dns to use v1 or v0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": "^5.5 || ^7.0",
         "php-http/httplug": "^1.0",
         "react/http-client": "~0.5.9",
-        "react/dns": "^0.4.15",
+        "react/dns": "^1.0|^0.4.15",
         "react/socket": "^1.0",
         "react/stream": "^1.0",
         "react/event-loop": "^1.0",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| Documentation   | no
| License         | MIT


#### What's in this PR?

Uses either the v1 or v0 of the `react/dns` package, depending on constraints.


#### Why?

Allows projects to update dependencies that depend on `react/dns` to newer versions.



#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
