### PR TITLE
Stop support for PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
-    - 5.5
     - 5.6
     - 7.0
     - 7.1
@@ -26,8 +25,6 @@ matrix:
         - php: hhvm
     fast_finish: true
     include:
-        - php: 5.5
-          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-ci"
         - php: hhvm
           dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
         - php: hhvm
     fast_finish: true
     include:
+        - php: 5.6
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-ci"
         - php: hhvm
           dist: trusty
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "php-http/httplug": "^1.0",
         "react/http-client": "~0.5.9",
         "react/dns": "^0.4.15",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | no
| Documentation   | no
| License         | MIT


#### What's in this PR?

Stop support for PHP 5.5


#### Why?

Prevents us from migrating to newer version of react components.