### PR TITLE
drop old php versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,9 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
-    - 5.6
-    - 7.0
     - 7.1
     - 7.2
+    - 7.3
 
 env:
     global:
@@ -21,17 +20,13 @@ branches:
         - /^analysis-.*$/
 
 matrix:
-    allow_failures:
-        - php: hhvm
     fast_finish: true
     include:
-        - php: 5.6
+        - php: 7.1
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-ci"
-        - php: hhvm
-          dist: trusty
 
 before_install:
-    - if [[ $COVERAGE != true && $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi
+    - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini; fi
 
 install:
     - travis_retry composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.1",
         "php-http/httplug": "^1.0",
         "react/http-client": "~0.5.9",
         "react/dns": "^0.4.15",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

Remove old PHP versions.


#### Why?

HHVM is dead, and PHP < 7.1 are not maintained at all anymore.

