### PR TITLE
Upgrade to react/http instead of react/http-client which is deprecated.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /phpspec.yml
 /phpunit.xml
 /vendor/
+.phpunit.result.cache

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -7,8 +7,5 @@ finder:
         - "src"
         - "tests"
 
-enabled:
-    - short_array_syntax
-
 disabled:
     - phpdoc_annotation_without_dot # This is still buggy: https://github.com/symfony/symfony/pull/19198

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Work with HTTPlug 2, drop HTTPlug 1 support
+- Move to `react/http` library instead of `react/http-client`
 
 ## [2.3.0] - 2019-07-30
 

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.4-dev"
+            "dev-master": "3.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,23 +7,20 @@
     "authors": [
         {
             "name": "Stéphane HULARD",
-            "email": "s.hulard@gmail.com"
+            "email": "s.hulard@chstudio.fr"
         }
     ],
     "require": {
         "php": "^7.1",
         "php-http/httplug": "^2.0",
-        "react/http-client": "~0.5.9",
-        "react/dns": "^1.0|^0.4.15",
-        "react/socket": "^1.0",
-        "react/stream": "^1.0",
+        "react/http": "^1.0",
         "react/event-loop": "^1.0",
         "php-http/discovery": "^1.0"
     },
     "require-dev": {
-        "php-http/client-integration-tests": "^2.0",
+        "php-http/client-integration-tests": "^3.0",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^4.8.36 || ^5.4"
+        "nyholm/psr7": "^1.3"
     },
     "provide": {
         "php-http/client-implementation": "1.0",

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,31 +4,22 @@ namespace Http\Adapter\React;
 
 use Http\Client\HttpClient;
 use Http\Client\HttpAsyncClient;
-use Http\Client\Exception\HttpException;
-use Http\Client\Exception\RequestException;
-use Http\Discovery\MessageFactoryDiscovery;
-use Http\Discovery\StreamFactoryDiscovery;
-use Http\Message\ResponseFactory;
-use Http\Message\StreamFactory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\StreamInterface;
 use React\EventLoop\LoopInterface;
-use React\HttpClient\Client as ReactClient;
-use React\HttpClient\Request as ReactRequest;
-use React\HttpClient\Response as ReactResponse;
+use React\Http\Browser as ReactBrowser;
 
 /**
  * Client for the React promise implementation.
  *
- * @author Stéphane Hulard <stephane@hlrd.me>
+ * @author Stéphane Hulard <s.hulard@chstudio.fr>
  */
 class Client implements HttpClient, HttpAsyncClient
 {
     /**
      * React HTTP client.
      *
-     * @var Client
+     * @var ReactBrowser
      */
     private $client;
 
@@ -40,40 +31,18 @@ class Client implements HttpClient, HttpAsyncClient
     private $loop;
 
     /**
-     * @var ResponseFactory
-     */
-    private $responseFactory;
-
-    /**
-     * @var StreamFactory
-     */
-    private $streamFactory;
-
-    /**
      * Initialize the React client.
-     *
-     * @param ResponseFactory|null $responseFactory
-     * @param LoopInterface|null   $loop
-     * @param ReactClient|null     $client
-     * @param StreamFactory|null   $streamFactory
      */
     public function __construct(
-        ResponseFactory $responseFactory = null,
         LoopInterface $loop = null,
-        ReactClient $client = null,
-        StreamFactory $streamFactory = null
+        ReactBrowser $client = null
     ) {
         if (null !== $client && null === $loop) {
-            throw new \RuntimeException(
-                'You must give a LoopInterface instance with the Client'
-            );
+            throw new \RuntimeException('You must give a LoopInterface instance with the Client');
         }
 
         $this->loop = $loop ?: ReactFactory::buildEventLoop();
         $this->client = $client ?: ReactFactory::buildHttpClient($this->loop);
-
-        $this->responseFactory = $responseFactory ?: MessageFactoryDiscovery::find();
-        $this->streamFactory = $streamFactory ?: StreamFactoryDiscovery::find();
     }
 
     /**
@@ -91,91 +60,17 @@ class Client implements HttpClient, HttpAsyncClient
      */
     public function sendAsyncRequest(RequestInterface $request)
     {
-        $reactRequest = $this->buildReactRequest($request);
-        $promise = new Promise($this->loop);
-
-        $reactRequest->on('error', function (\Exception $error) use ($promise, $request) {
-            $promise->reject(new RequestException(
-                $error->getMessage(),
-                $request,
-                $error
-            ));
-        });
-
-        $reactRequest->on('response', function (ReactResponse $reactResponse = null) use ($promise, $request) {
-            $bodyStream = $this->streamFactory->createStream();
-            $reactResponse->on('data', function ($data) use (&$bodyStream) {
-                $bodyStream->write((string) $data);
-            });
-
-            $reactResponse->on('end', function (\Exception $error = null) use ($promise, $request, $reactResponse, &$bodyStream) {
-                $response = $this->buildResponse(
-                    $reactResponse,
-                    $bodyStream
-                );
-                if (null !== $error) {
-                    $promise->reject(new HttpException(
-                        $error->getMessage(),
-                        $request,
-                        $response,
-                        $error
-                    ));
-                } else {
-                    $promise->resolve($response);
-                }
-            });
-        });
-
-        $reactRequest->end((string) $request->getBody());
+        $promise = new Promise(
+            $this->client->request(
+                $request->getMethod(),
+                $request->getUri(),
+                $request->getHeaders(),
+                $request->getBody()
+            ),
+            $this->loop,
+            $request
+        );
 
         return $promise;
-    }
-
-    /**
-     * Build a React request from the PSR7 RequestInterface.
-     *
-     * @param RequestInterface $request
-     *
-     * @return ReactRequest
-     */
-    private function buildReactRequest(RequestInterface $request)
-    {
-        $headers = [];
-
-        foreach ($request->getHeaders() as $name => $value) {
-            $headers[$name] = (is_array($value) ? $value[0] : $value);
-        }
-
-        $reactRequest = $this->client->request(
-            $request->getMethod(),
-            (string) $request->getUri(),
-            $headers,
-            $request->getProtocolVersion()
-        );
-
-        return $reactRequest;
-    }
-
-    /**
-     * Transform a React Response to a valid PSR7 ResponseInterface instance.
-     *
-     * @param ReactResponse   $response
-     * @param StreamInterface $body
-     *
-     * @return ResponseInterface
-     */
-    private function buildResponse(
-        ReactResponse $response,
-        StreamInterface $body
-    ) {
-        $body->rewind();
-
-        return $this->responseFactory->createResponse(
-            $response->getCode(),
-            $response->getReasonPhrase(),
-            $response->getHeaders(),
-            $body,
-            $response->getVersion()
-        );
     }
 }

--- a/src/ReactFactory.php
+++ b/src/ReactFactory.php
@@ -4,17 +4,13 @@ namespace Http\Adapter\React;
 
 use React\EventLoop\LoopInterface;
 use React\EventLoop\Factory as EventLoopFactory;
-use React\Dns\Resolver\Resolver as DnsResolver;
-use React\Dns\Resolver\Factory as DnsResolverFactory;
-use React\HttpClient\Client as HttpClient;
-use React\HttpClient\Factory as HttpClientFactory;
-use React\Socket\Connector;
+use React\Http\Browser;
 use React\Socket\ConnectorInterface;
 
 /**
  * Factory wrapper for React instances.
  *
- * @author Stéphane Hulard <stephane@hlrd.me>
+ * @author Stéphane Hulard <s.hulard@chstudio.fr>
  */
 class ReactFactory
 {
@@ -29,118 +25,20 @@ class ReactFactory
     }
 
     /**
-     * Build a React Dns Resolver.
-     *
-     * @param LoopInterface $loop
-     * @param string        $dns
-     *
-     * @return DnsResolver
-     */
-    public static function buildDnsResolver(
-        LoopInterface $loop,
-        $dns = '8.8.8.8'
-    ) {
-        $factory = new DnsResolverFactory();
-
-        return $factory->createCached($dns, $loop);
-    }
-
-    /**
-     * @param LoopInterface    $loop
-     * @param DnsResolver|null $dns
-     *
-     * @return ConnectorInterface
-     */
-    public static function buildConnector(
-        LoopInterface $loop,
-        DnsResolver $dns = null
-    ) {
-        return null !== $dns
-            ? new Connector($loop, ['dns' => $dns])
-            : new Connector($loop);
-    }
-
-    /**
      * Build a React Http Client.
      *
-     * @param LoopInterface                       $loop
-     * @param ConnectorInterface|DnsResolver|null $connector Only pass this argument if you need to customize DNS
-     *                                                       behaviour. With react http client v0.5, pass a connector,
-     *                                                       with v0.4 this must be a DnsResolver.
+     * @param LoopInterface           $loop
+     * @param ConnectorInterface|null $connector Only pass this argument if you need to customize DNS
+     *                                           behaviour.
      *
-     * @return HttpClient
+     * @return Browser
      */
     public static function buildHttpClient(
         LoopInterface $loop,
-        $connector = null
-    ) {
-        if (class_exists(HttpClientFactory::class)) {
-            // if HttpClientFactory class exists, use old behavior for backwards compatibility
-            return static::buildHttpClient04($loop, $connector);
-        } else {
-            return static::buildHttpClient05($loop, $connector);
-        }
-    }
-
-    /**
-     * Builds a React Http client v0.4 style.
-     *
-     * @param LoopInterface    $loop
-     * @param DnsResolver|null $dns
-     *
-     * @return HttpClient
-     */
-    protected static function buildHttpClient04(
-        LoopInterface $loop,
-        $dns = null
-    ) {
-        // create dns resolver if one isn't provided
-        if (null === $dns) {
-            $dns = static::buildDnsResolver($loop);
-        }
-
-        // validate connector instance for proper error reporting
-        if (!$dns instanceof DnsResolver) {
-            throw new \InvalidArgumentException('For react http client v0.4, $dns must be an instance of DnsResolver');
-        }
-
-        $factory = new HttpClientFactory();
-
-        return $factory->create($loop, $dns);
-    }
-
-    /**
-     * Builds a React Http client v0.5 style.
-     *
-     * @param LoopInterface                       $loop
-     * @param DnsResolver|ConnectorInterface|null $connector
-     *
-     * @return HttpClient
-     */
-    protected static function buildHttpClient05(
-        LoopInterface $loop,
-        $connector = null
-    ) {
-        // build a connector with given DnsResolver if provided (old deprecated behavior)
-        if ($connector instanceof DnsResolver) {
-            @trigger_error(
-                sprintf(
-                    'Passing a %s to buildHttpClient is deprecated since version 2.1.0 and will be removed in 3.0. If you need no specific behaviour, omit the $dns argument, otherwise pass a %s',
-                    DnsResolver::class,
-                    ConnectorInterface::class
-                ),
-                E_USER_DEPRECATED
-            );
-            $connector = static::buildConnector($loop, $connector);
-        }
-
-        // validate connector instance for proper error reporting
-        if (null !== $connector && !$connector instanceof ConnectorInterface) {
-            throw new \InvalidArgumentException(
-                '$connector must be an instance of DnsResolver or ConnectorInterface'
-            );
-        }
-
-        return new HttpClient($loop, $connector);
+        ConnectorInterface $connector = null
+    ): Browser {
+        return (new Browser($loop, $connector))
+            ->withRejectErrorResponse(false)
+            ->withFollowRedirects(false);
     }
 }

--- a/src/ReactFactory.php
+++ b/src/ReactFactory.php
@@ -16,10 +16,8 @@ class ReactFactory
 {
     /**
      * Build a react Event Loop.
-     *
-     * @return LoopInterface
      */
-    public static function buildEventLoop()
+    public static function buildEventLoop(): LoopInterface
     {
         return EventLoopFactory::create();
     }
@@ -27,11 +25,8 @@ class ReactFactory
     /**
      * Build a React Http Client.
      *
-     * @param LoopInterface           $loop
      * @param ConnectorInterface|null $connector Only pass this argument if you need to customize DNS
      *                                           behaviour.
-     *
-     * @return Browser
      */
     public static function buildHttpClient(
         LoopInterface $loop,

--- a/tests/AsyncClientTest.php
+++ b/tests/AsyncClientTest.php
@@ -2,21 +2,17 @@
 
 namespace Http\Adapter\React\Tests;
 
-use Http\Client\HttpClient;
 use Http\Client\Tests\HttpAsyncClientTest;
 use Http\Adapter\React\Client;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Http\Client\HttpAsyncClient;
 
 /**
- * @author Stéphane Hulard <stephane@hlrd.me>
+ * @author Stéphane Hulard <s.hulard@chstudio.fr>
  */
 class AsyncClientTest extends HttpAsyncClientTest
 {
-    /**
-     * @return HttpClient
-     */
-    protected function createHttpAsyncClient()
+    protected function createHttpAsyncClient(): HttpAsyncClient
     {
-        return new Client(new GuzzleMessageFactory());
+        return new Client();
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -2,21 +2,17 @@
 
 namespace Http\Adapter\React\Tests;
 
-use Http\Client\HttpClient;
 use Http\Client\Tests\HttpClientTest;
 use Http\Adapter\React\Client;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Psr\Http\Client\ClientInterface;
 
 /**
- * @author Stéphane Hulard <stephane@hlrd.me>
+ * @author Stéphane Hulard <s.hulard@chstudio.fr>
  */
 class ClientTest extends HttpClientTest
 {
-    /**
-     * @return HttpClient
-     */
-    protected function createHttpAdapter()
+    protected function createHttpAdapter(): ClientInterface
     {
-        return new Client(new GuzzleMessageFactory());
+        return new Client();
     }
 }

--- a/tests/ReactFactoryTest.php
+++ b/tests/ReactFactoryTest.php
@@ -4,10 +4,8 @@ namespace Http\Adapter\React\Tests;
 
 use Http\Adapter\React\ReactFactory;
 use PHPUnit\Framework\TestCase;
-use React\Dns\Resolver\Resolver;
 use React\EventLoop\LoopInterface;
-use React\HttpClient\Client;
-use React\HttpClient\Factory;
+use React\Http\Browser;
 use React\Socket\ConnectorInterface;
 
 /**
@@ -23,45 +21,22 @@ class ReactFactoryTest extends TestCase
      */
     private $loop;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->loop = $this->getMockBuilder(LoopInterface::class)->getMock();
     }
 
     public function testBuildHttpClientWithConnector()
     {
-        if (class_exists(Factory::class)) {
-            $this->markTestSkipped('This test only runs with react http client v0.5 and above');
-        }
-
+        /** @var ConnectorInterface $connector */
         $connector = $this->getMockBuilder(ConnectorInterface::class)->getMock();
         $client = ReactFactory::buildHttpClient($this->loop, $connector);
-        $this->assertInstanceOf(Client::class, $client);
-    }
-
-    /**
-     * @deprecated Building HTTP client passing a DnsResolver instance is deprecated. Should pass a ConnectorInterface
-     *             instance instead.
-     */
-    public function testBuildHttpClientWithDnsResolver()
-    {
-        $connector = $this->getMockBuilder(Resolver::class)->disableOriginalConstructor()->getMock();
-        $client = ReactFactory::buildHttpClient($this->loop, $connector);
-        $this->assertInstanceOf(Client::class, $client);
+        $this->assertInstanceOf(Browser::class, $client);
     }
 
     public function testBuildHttpClientWithoutConnector()
     {
         $client = ReactFactory::buildHttpClient($this->loop);
-        $this->assertInstanceOf(Client::class, $client);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testBuildHttpClientWithInvalidConnectorThrowsException()
-    {
-        $connector = $this->getMockBuilder(LoopInterface::class)->getMock();
-        ReactFactory::buildHttpClient($this->loop, $connector);
+        $this->assertInstanceOf(Browser::class, $client);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | fixes #41
| License         | MIT


#### What's in this PR?

The adapter now rely on `react/http` instead of `react/http-client`. The `Client` external behaviour hasn't changed but all the inner logic is now rewritten.

Because `react/http` hasn't a compatible signature with `react/http-client` this is a BC Break and will require a new major version of the adapter.


#### Why?

`react/http-client` is now deprecated so we must move with the ecosystem.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)
