### PR TITLE
Prepare v2.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [2.4.0] - 2020-12-0317
+
+### Changed
+
 - Work with HTTPlug 2, drop HTTPlug 1 support
 
 ## [2.3.0] - 2019-07-30


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | 
| License         | MIT


#### What's in this PR?

Just update the changelog to prepare the v2.4.0 release.


#### Why?

Because I think it's important to release the v2.4.0 tag before the v3.0.0 (cf #42).
