### PR TITLE
Detect supported PHP versions in range during CI instead of hardcoding them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,23 @@ on:
   pull_request:
 
 jobs:
+  supported-versions-matrix:
+    name: Supported Versions Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.supported-versions-matrix.outputs.version }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: supported-versions-matrix
+        uses: WyriHaximus/github-action-composer-php-versions-in-range@v1
   latest:
     name: PHP ${{ matrix.php }} Latest
     runs-on: ubuntu-latest
+    needs:
+      - supported-versions-matrix
     strategy:
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0']
+        php: ${{ fromJson(needs.supported-versions-matrix.outputs.version) }}
 
     steps:
       - name: Checkout code
@@ -35,9 +46,11 @@ jobs:
   lowest:
     name: PHP ${{ matrix.php }} Lowest
     runs-on: ubuntu-latest
+    needs:
+      - supported-versions-matrix
     strategy:
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4']
+        php: ${{ fromJson(needs.supported-versions-matrix.outputs.version) }}
 
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Detect supported PHP versions in range during CI instead of hardcoding them
+
 ### Changed
 
 ## [3.0.1] - 2021-10-20

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "php-http/httplug": "^2.0",
         "react/http": "^1.0",
         "react/event-loop": "^1.2",
-        "php-http/discovery": "^1.0"
+        "php-http/discovery": "^1.0",
+        "phpunit/phpunit": "^9.3.11 || ^7"
     },
     "require-dev": {
         "php-http/client-integration-tests": "^3.0",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | blocks #50, relates to #51
| License         | MIT


#### What's in this PR?

The proposed changes use a GitHub Actions I created to detect supported PHP version in range of composer.json.


#### Why?

To lower maintenance when new PHP releases come out in the future.
#### Checklist

- [X] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
